### PR TITLE
Explicitly declare input and output files for svgo

### DIFF
--- a/Minify.py
+++ b/Minify.py
@@ -197,7 +197,7 @@ class BeautifyClass(MinifyUtils):
 				eo = self.get_setting('svgo_pretty_options')
 				if type(eo).__name__ in ('str', 'unicode'):
 					cmd.extend(self.fixStr(eo).split())
-				cmd.extend(['--pretty', self.quoteChrs(inpfile), self.quoteChrs(outfile)])
+				cmd.extend(['--pretty', '-i', self.quoteChrs(inpfile), '-o', self.quoteChrs(outfile)])
 			if cmd:
 				print('Minify: Beautifying file:' + str(inpfile))
 				self.run_cmd(cmd, outfile)

--- a/Minify.py
+++ b/Minify.py
@@ -154,7 +154,7 @@ class MinifyClass(MinifyUtils):
 				eo = self.get_setting('svgo_min_options')
 				if type(eo).__name__ in ('str', 'unicode'):
 					cmd.extend(self.fixStr(eo).split())
-				cmd.extend([self.quoteChrs(inpfile), self.quoteChrs(outfile)])
+				cmd.extend(['-i', self.quoteChrs(inpfile), '-o', self.quoteChrs(outfile)])
 			else:
 				cmd = False
 			if cmd:


### PR DESCRIPTION
## TL;DR
SVG file minimization would fail when the input and output files were passed positionally.  Explicitly specifying input and output paths fixes this.

### Full explanation

Attempting to minify a SVG file was resulting in an error.

![sublime error](https://user-images.githubusercontent.com/6391930/41932129-c6598ae8-7945-11e8-87c4-1b885814368a.png)

When running the command from the CLI I was also getting an error

```powershell
Error: Error: no such file or directory 'C:\test\test.min.svg'.
    at checkOptimizeFileError (D:\nodejs\node_modules\svgo\lib\svgo\coa.js:465:31)
    at readFile.then.error (D:\nodejs\node_modules\svgo\lib\svgo\coa.js:378:18)
```
Current version of modules

module | version
--- | ---
cleancss | 4.1.11
uglifycss | uglifycss 0.0.29
js-beautify | 1.7.5
html-minifier | 3.5.16
uglifyjs | uglify-js 3.4.1
minjson | minjson v0.0.2
svgo | 1.0.5

Found that the problem was `svgo` wasn't accepting positional arguments for input and output files.  This was fixed with a positional input file and an argument specified output file.  Or just explicitly specifying input and output files.

Console results when specifying `-i` and `-o` parameters

```powershell
PS C:\test> svgo --version
1.0.5
PS C:\test> svgo
Nodejs-based tool for optimizing SVG vector graphics files

Usage:
  svgo [OPTIONS] [ARGS]


Options:
  -h, --help : Help
  -v, --version : Version
  -i INPUT, --input=INPUT : Input file, "-" for STDIN
  -s STRING, --string=STRING : Input SVG data string
  -f FOLDER, --folder=FOLDER : Input folder, optimize and rewrite all *.svg files
  -o OUTPUT, --output=OUTPUT : Output file or folder (by default the same as the input), "-" for STDOUT
  -p PRECISION, --precision=PRECISION : Set number of digits in the fractional part, overrides plugins p
arams
  --config=CONFIG : Config file or JSON string to extend or replace default
  --disable=DISABLE : Disable plugin by name
  --enable=ENABLE : Enable plugin by name
  --datauri=DATAURI : Output as Data URI string (base64, URI encoded or unencoded)
  --multipass : Enable multipass
  --pretty : Make SVG pretty printed
  --indent=INDENT : Indent number when pretty printing SVGs
  -q, --quiet : Only output error messages, not regular status messages
  --show-plugins : Show available plugins and exit

Arguments:
  INPUT : Alias to --input
PS C:\test> svgo C:\test\test.svg C:\test\test.min.svg
Error: Error: no such file or directory 'C:\test\test.min.svg'.
    at checkOptimizeFileError (D:\nodejs\node_modules\svgo\lib\svgo\coa.js:465:31)
    at readFile.then.error (D:\nodejs\node_modules\svgo\lib\svgo\coa.js:378:18)
PS C:\test> svgo C:\test\test.svg -o C:\test\test.min.svg

test.svg:
Done in 13 ms!
1.204 KiB - 58.3% = 0.502 KiB
PS C:\test> ls


    Directory: C:\test


Mode                LastWriteTime         Length Name
----                -------------         ------ ----
-a----        6/26/2018   1:43 PM            514 test.min.svg
-a----        6/26/2018  12:52 PM           1233 test.svg


PS C:\test> svgo -i C:\test\test.svg -o C:\test\test.min2.svg

test.svg:
Done in 13 ms!
1.204 KiB - 58.3% = 0.502 KiB
PS C:\test> ls


    Directory: C:\test


Mode                LastWriteTime         Length Name
----                -------------         ------ ----
-a----        6/26/2018   1:43 PM            514 test.min.svg
-a----        6/26/2018   1:43 PM            514 test.min2.svg
-a----        6/26/2018  12:52 PM           1233 test.svg
```

![svgo error](https://user-images.githubusercontent.com/6391930/41932743-7d4db94e-7947-11e8-905e-33062f40bd91.png)
