### PR TITLE
Add "js_require_comment" setting to easily ignore server-side files

### DIFF
--- a/Minify.py
+++ b/Minify.py
@@ -112,7 +112,7 @@ class MinifyClass(MinifyUtils):
 			if re.search(r'\.js$', inpfile) or re.search(r'/JavaScript\.tmLanguage$', syntax):
 
 				# Read file line and check for inline parameters
-				if self.get_setting('js_comment'):
+				if self.get_setting('js_require_comment'):
 					minify_inline_found = False
 					minify_inline_allowed = False
 

--- a/Minify.py
+++ b/Minify.py
@@ -116,7 +116,7 @@ class MinifyClass(MinifyUtils):
 					minify_inline_found = False
 					minify_inline_allowed = False
 
-					with open(inpfile) as file:
+					with open(inpfile, encoding='utf8') as file:
 						first_line = file.readline().rstrip()
 						regex_search = re.search('// {([a-z:, ]+)}', first_line)
 

--- a/Minify.sublime-settings
+++ b/Minify.sublime-settings
@@ -85,6 +85,10 @@
 	// if you need a source map in the destination directory (same as original source), enable this option
 	"source_map": false,
 
+  // change to true to require the comment below on the first line of JS file to minify the file:
+  // {minify:true}
+  "js_comment": false,
+
 	// change to true if you are using any transpiler such as Babel or Typescript that generate map files for original code
 	// map file must be present in the same directory
 	"js_map_content": false,

--- a/Minify.sublime-settings
+++ b/Minify.sublime-settings
@@ -87,7 +87,7 @@
 
   // change to true to require the comment below on the first line of JS file to minify the file:
   // {minify:true}
-  "js_comment": false,
+  "js_require_comment": false,
 
 	// change to true if you are using any transpiler such as Babel or Typescript that generate map files for original code
 	// map file must be present in the same directory


### PR DESCRIPTION
I really like this package to minify my files using the `auto_minify_on_save` setting but unfortunately it tries to minify my server-side files on my node.js application every time I make a change. I suggest adding a new setting `js_require_comment` to require a comment on the first line of JS files so the user can disable the minify action per file when the `auto_minify_on_save` setting is enabled.

Client-side scripts would require this comment `// {minify:true}` on the first line of the script if this setting is enabled and server-side scripts would need to have this inline option set to false or don't use the comment at all.