### PR TITLE
smallfix for unknown option '--skip-rebase' #85

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@ dependencies are provided below.
 
 3. Install required Node.js CLI apps:<br><br>
   From a shell window (`Terminal` on Mac OS X, `CMD.exe` on Windows) issue the following command:<br><br>
-  `npm install -g clean-css-cli uglifycss js-beautify html-minifier uglify-js minjson svgo`<br><br>
+  `npm install -g clean-css@3.4.24 uglifycss js-beautify html-minifier uglify-js minjson svgo`<br><br>
   Notes:<br><br>
   If you are on Mac OS X and you get an error here then issue the following command from `Terminal`:
   `sudo chown -R $USER /usr/local` and then try to issue the npm install command from above again.<br><br>
@@ -62,7 +62,7 @@ dependencies are provided below.
   install command. You can also leave out `uglifycss`, etc.<br><br>
   If you already have some or all of the above Node.js CLI apps installed on your system then it is
   recommended to update them all to the latest version with the following command:<br><br>
-  `npm update -g clean-css-cli uglifycss js-beautify html-minifier uglify-js minjson svgo`<br><br>
+  `npm update -g clean-css@3.4.24 uglifycss js-beautify html-minifier uglify-js minjson svgo`<br><br>
   Please test that the installed Node.js CLI apps are available via your `PATH`, here is how:<br><br>
   Still from a shell window (`Terminal` on Mac OS X, `CMD.exe` on Windows) issue the following command,
   for example:<br><br>
@@ -72,7 +72,7 @@ dependencies are provided below.
   You may want to do this test for all Node.js CLI apps (`cleancss`, `uglifycss`, `js-beautify`, `html-minifier`,
   `uglifyjs`, `minjson` and `svgo`).<br><br>
 
-##How to use `Minify`
+## How to use `Minify`
 
 Open a `.css` or `.htm` or `.html` or `.js` or `.json` or `.svg` file in your Sublime Text editor and you can
 
@@ -111,7 +111,7 @@ Please do not edit the **Settings - Default** file!!
 Also, you can override the default and user settings for individual projects. Just add a "Minify" object to the "settings" object
 in the project's .sublime-project file containing your [project specific settings](http://www.sublimetext.com/docs/3/projects.html).
 
-###Example:
+### Example:
 
 ```json
 {
@@ -129,6 +129,6 @@ in the project's .sublime-project file containing your [project specific setting
 }
 ```
 
-##License
+## License
 
 See [LICENSE.md](https://github.com/tssajo/Minify/blob/master/LICENSE.md) file for licensing information.


### PR DESCRIPTION
```bash
cleancss -O2 --skip-rebase -o /path/to/file/style.css
error: unknown option '--skip-rebase'
```

reference issue:  #85
thank you to: @input-username-here for suggest

* Update node clean-css using exact version **clean-css@3.4.24**
* Fix typo on README (part example and license)

**Note:**
This is just for **temporary** solution, before you make an update to functionality of this package. Please update the Readme section, so other people like me can use your package properly, specially for minify css code.

_Regard's
ian_